### PR TITLE
Add support for `embedded-hal-async` I2C traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ license-file="LICENSE"
 
 [dependencies]
 embedded-hal = "0.2"
+embedded-hal-async = "0.1.0-alpha.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ categories = ["embedded", "hardware-support", "no-std"]
 readme="README.md"
 license-file="LICENSE"
 
+[features]
+default = ["blocking"]
+blocking = ["embedded-hal"]
+async = ["embedded-hal-async"]
+
 [dependencies]
-embedded-hal = "0.2"
-embedded-hal-async = "0.1.0-alpha.1"
+embedded-hal = { version = "0.2", optional = true }
+embedded-hal-async = {version = "0.1.0-alpha.1", optional = true }
+maybe-async-cfg = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,13 @@ impl<I2C, E> Lsm6ds33<I2C>
         self.write_register_option(Register::Ctrl2G, scale).await
     }
 
+    /// Set the low power mode
+    pub async fn set_low_power_mode(&mut self, low_power: bool) -> Result<(), Error<E>> {
+        // N.B. "1" means low-power, "0" means high-performance.
+        self.write_bit(Register::Ctrl6C, low_power as u8, Ctrl6C::AccelHighPerformanceMode as u8).await?;
+        self.write_bit(Register::Ctrl7G, low_power as u8, Ctrl7G::HighPerformanceMode as u8).await
+    }
+
     /// Read the gyroscope data for each axis (RAD/s)
     pub async fn read_gyro(&mut self) -> Result<(f32, f32, f32), Error<E>> {
         // Read the raw gyro data from the IMU

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,11 @@ pub use regs::{
     GyroscopeFullScale, GyroscopeOutput,
 };
 
+use maybe_async_cfg;
+
+#[cfg(feature = "blocking")]
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+#[cfg(feature = "async")]
 use embedded_hal_async::i2c::I2c;
 
 /// Enum containing all possible types of errors when interacting with the IMU
@@ -41,13 +46,15 @@ const CHIP_ID: u8 = 0x69;
 const EARTH_GRAVITY: f32 = 9.80665;
 
 /// 6-DoF IMU accelerometer + gyro
+#[maybe_async_cfg::maybe(sync(feature="blocking", keep_self), async(feature="async"))]
 pub struct Lsm6ds33<I2C> {
     i2c: I2C,
     addr: u8,
 }
 
+#[maybe_async_cfg::maybe(sync(feature="blocking", keep_self), async(feature="async", idents(Write(async="I2c"),WriteRead(async="I2c"))))]
 impl<I2C, E> Lsm6ds33<I2C>
-    where I2C: I2c<Error = E> {
+    where I2C: Write<Error = E> + WriteRead<Error = E> {
 
     /// Create an instance of the Lsm6ds33 driver
     /// If the device cannot be detected on the bus, an error will be returned

--- a/src/regs.rs
+++ b/src/regs.rs
@@ -316,3 +316,18 @@ pub enum Ctrl3C {
     Endian = 1,
     SoftwareReset = 0,
 }
+
+/// Bit fields for CTRL6_C
+pub enum Ctrl6C {
+    GyroEdgeTrigge = 7,
+    GyroLevelTrigger = 6,
+    GyroLevelLatched = 5,
+    AccelHighPerformanceMode = 4,
+}
+
+/// Bit fields for CTRL6_G
+pub enum Ctrl7G {
+    HighPerformanceMode = 7,
+    HighPassFilter = 6,
+    SourceRegisterRounding = 3,
+}


### PR DESCRIPTION
This uses `maybe-async-cfg` to automatically remove the `async` and `.await` keywords from the blocking version.

It also exposes the performance mode settings, since those were previously not exposed; let me know if you want me to split that into its own PR.