### PR TITLE
Reduce the number of I2C transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ blocking = ["embedded-hal"]
 async = ["embedded-hal-async"]
 
 [dependencies]
+arrayref = "0.3.6"
 embedded-hal = { version = "0.2", optional = true }
 embedded-hal-async = {version = "0.1.0-alpha.1", optional = true }
 maybe-async-cfg = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,14 @@
 #![allow(unused)]
 mod regs;
 
+use arrayref::array_refs;
 use core::convert::TryFrom;
 
 use regs::*;
 
 pub use regs::{
-    AccelerometerBandwidth, AccelerometerOutput, AccelerometerScale,
-    GyroscopeFullScale, GyroscopeOutput,
+    AccelerometerBandwidth, AccelerometerOutput, AccelerometerScale, GyroscopeFullScale,
+    GyroscopeOutput,
 };
 
 use maybe_async_cfg;
@@ -46,27 +47,39 @@ const CHIP_ID: u8 = 0x69;
 const EARTH_GRAVITY: f32 = 9.80665;
 
 /// 6-DoF IMU accelerometer + gyro
-#[maybe_async_cfg::maybe(sync(feature="blocking", keep_self), async(feature="async"))]
+#[maybe_async_cfg::maybe(sync(feature = "blocking", keep_self), async(feature = "async"))]
 pub struct Lsm6ds33<I2C> {
     i2c: I2C,
     addr: u8,
+    accelerometer_scale: Option<AccelerometerScale>,
+    gyroscope_scale: Option<GyroscopeFullScale>,
 }
 
-#[maybe_async_cfg::maybe(sync(feature="blocking", keep_self), async(feature="async", idents(Write(async="I2c"),WriteRead(async="I2c"))))]
+#[maybe_async_cfg::maybe(
+    sync(feature = "blocking", keep_self),
+    async(
+        feature = "async",
+        idents(Write(async = "I2c"), WriteRead(async = "I2c"))
+    )
+)]
 impl<I2C, E> Lsm6ds33<I2C>
-    where I2C: Write<Error = E> + WriteRead<Error = E> {
-
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+{
     /// Create an instance of the Lsm6ds33 driver
     /// If the device cannot be detected on the bus, an error will be returned
     pub async fn new(i2c: I2C, addr: u8) -> Result<Self, (I2C, Error<E>)> {
-        let mut lsm = Lsm6ds33 {i2c, addr};
+        let mut lsm = Lsm6ds33 {
+            i2c,
+            addr,
+            accelerometer_scale: None,
+            gyroscope_scale: None,
+        };
 
         match lsm.check().await {
-            Ok(true) => {
-                match lsm.set_auto_increment(true).await {
-                    Ok(()) => Ok(lsm),
-                    Err(e) => Err((lsm.release(), e)),
-                }
+            Ok(true) => match lsm.set_auto_increment(true).await {
+                Ok(()) => Ok(lsm),
+                Err(e) => Err((lsm.release(), e)),
             },
             Ok(false) => Err((lsm.release(), Error::ChipDetectFailed)),
             Err(e) => Err((lsm.release(), e)),
@@ -74,18 +87,37 @@ impl<I2C, E> Lsm6ds33<I2C>
     }
 
     /// Set the accelerometer output rate
-    pub async fn set_accelerometer_output(&mut self, output: AccelerometerOutput) -> Result<(), Error<E>> {
+    pub async fn set_accelerometer_output(
+        &mut self,
+        output: AccelerometerOutput,
+    ) -> Result<(), Error<E>> {
         self.write_register_option(Register::Ctrl1XL, output).await
     }
 
     /// Set the accelerometer operating range
-    pub async fn set_accelerometer_scale(&mut self, scale: AccelerometerScale) -> Result<(), Error<E>> {
-        self.write_register_option(Register::Ctrl1XL, scale).await
+    pub async fn set_accelerometer_scale(
+        &mut self,
+        scale: AccelerometerScale,
+    ) -> Result<(), Error<E>> {
+        match self.write_register_option(Register::Ctrl1XL, scale).await {
+            Ok(()) => {
+                self.accelerometer_scale = Some(scale);
+                Ok(())
+            }
+            Err(e) => {
+                self.accelerometer_scale = None;
+                Err(e)
+            }
+        }
     }
 
     /// Set the accelerometer bandwidth filter
-    pub async fn set_accelerometer_bandwidth(&mut self, bandwidth: AccelerometerBandwidth) -> Result<(), Error<E>> {
-        self.write_register_option(Register::Ctrl1XL, bandwidth).await
+    pub async fn set_accelerometer_bandwidth(
+        &mut self,
+        bandwidth: AccelerometerBandwidth,
+    ) -> Result<(), Error<E>> {
+        self.write_register_option(Register::Ctrl1XL, bandwidth)
+            .await
     }
 
     /// Set the gyroscope output rate
@@ -95,56 +127,97 @@ impl<I2C, E> Lsm6ds33<I2C>
 
     /// Set the gyroscope operating range
     pub async fn set_gyroscope_scale(&mut self, scale: GyroscopeFullScale) -> Result<(), Error<E>> {
-        self.write_register_option(Register::Ctrl2G, scale).await
+        match self.write_register_option(Register::Ctrl2G, scale).await {
+            Ok(()) => {
+                self.gyroscope_scale = Some(scale);
+                Ok(())
+            }
+            Err(e) => {
+                self.accelerometer_scale = None;
+                Err(e)
+            }
+        }
     }
 
     /// Set the low power mode
     pub async fn set_low_power_mode(&mut self, low_power: bool) -> Result<(), Error<E>> {
         // N.B. "1" means low-power, "0" means high-performance.
-        self.write_bit(Register::Ctrl6C, low_power as u8, Ctrl6C::AccelHighPerformanceMode as u8).await?;
-        self.write_bit(Register::Ctrl7G, low_power as u8, Ctrl7G::HighPerformanceMode as u8).await
+        self.write_bit(
+            Register::Ctrl6C,
+            low_power as u8,
+            Ctrl6C::AccelHighPerformanceMode as u8,
+        )
+        .await?;
+        self.write_bit(
+            Register::Ctrl7G,
+            low_power as u8,
+            Ctrl7G::HighPerformanceMode as u8,
+        )
+        .await
+    }
+
+    /// Read all three sensors in one transaction. Returns temperature, gyro, accelerometer.
+    pub async fn read_all(&mut self) -> Result<(f32, (f32, f32, f32), (f32, f32, f32)), Error<E>> {
+        let gyro_scale = self.read_gyroscope_scale().await?;
+        let accel_scale = self.read_accelerometer_scale().await?;
+        let data = self.read_registers::<14>(Register::OutTempL).await?;
+        let (temp, gyro, accel) = array_refs!(&data, 2, 6, 6);
+        Ok((
+            Self::convert_temp_data(temp),
+            Self::convert_gyro_data(gyro, gyro_scale),
+            Self::convert_accel_data(accel, accel_scale),
+        ))
     }
 
     /// Read the gyroscope data for each axis (RAD/s)
     pub async fn read_gyro(&mut self) -> Result<(f32, f32, f32), Error<E>> {
-        // Read the raw gyro data from the IMU
-        let (x, y, z) = self.read_gyro_raw().await?;
-        // Get the set gyro full scale parameter
-        let scale = self.read_gyroscope_scale().await?.scale();
+        let scale = self.read_gyroscope_scale().await?;
+        self.read_registers(Register::OutXLG)
+            .await
+            .map(|res| Self::convert_gyro_data(&res, scale))
+    }
+
+    fn convert_gyro_data(data: &[u8; 6], scale: GyroscopeFullScale) -> (f32, f32, f32) {
         // Convert raw data to float
-        let (x, y, z) = (x as f32, y as f32, z as f32);
+        let (x, y, z) = Self::u8_to_f32(data);
+        let scale = scale.scale();
         // Convert to RAD/s (Raw gyro data is in milli-degrees per second per bit)
-        Ok(
-            (
-                (x * scale / 1000.0).to_radians(),
-                (y * scale / 1000.0).to_radians(),
-                (z * scale / 1000.0).to_radians(),
-            )
+        (
+            (x * scale / 1000.0).to_radians(),
+            (y * scale / 1000.0).to_radians(),
+            (z * scale / 1000.0).to_radians(),
         )
     }
 
     /// Read the accelerometer data for each axis (m/s^2)
     pub async fn read_accelerometer(&mut self) -> Result<(f32, f32, f32), Error<E>> {
-        let (x, y, z) = self.read_accelerometer_raw().await?;
-        let scale = self.read_accelerometer_scale().await?.scale();
+        let scale = self.read_accelerometer_scale().await?;
+        self.read_registers(Register::OutXLXL)
+            .await
+            .map(|res| Self::convert_accel_data(&res, scale))
+    }
 
+    fn convert_accel_data(data: &[u8; 6], scale: AccelerometerScale) -> (f32, f32, f32) {
         // Convert raw values to float
-        let (x, y, z) = (x as f32, y as f32, z as f32);
+        let (x, y, z) = Self::u8_to_f32(data);
+        let scale = scale.scale();
 
         // Convert to m/s^2 (Raw value is in mg/bit)
-        Ok(
-            (
-                (x * scale / 1000.0) * EARTH_GRAVITY,
-                (y * scale / 1000.0) * EARTH_GRAVITY,
-                (z * scale / 1000.0) * EARTH_GRAVITY,
-            )
+        (
+            (x * scale / 1000.0) * EARTH_GRAVITY,
+            (y * scale / 1000.0) * EARTH_GRAVITY,
+            (z * scale / 1000.0) * EARTH_GRAVITY,
         )
     }
 
-    /// Read the temperature
+    /// Read the temperature (degC)
     pub async fn read_temperature(&mut self) -> Result<f32, Error<E>> {
-        let lo = self.read_register(Register::OutTempL).await?;
-        let hi = self.read_register(Register::OutTempH).await?;
+        let data = self.read_registers::<2>(Register::OutTempL).await?;
+        Ok(Self::convert_temp_data(&data))
+    }
+
+    fn convert_temp_data(data: &[u8; 2]) -> f32 {
+        let (lo, hi) = (data[0], data[1]);
 
         // Raw temperature as signal 16-bit number
         let temperature = ((hi as i16) << 8) | (lo as i16);
@@ -153,7 +226,7 @@ impl<I2C, E> Lsm6ds33<I2C>
         // Converted given the temperature sensitively value 16 bits per C
         let temperature = (temperature / 16.0) + 25.0;
 
-        Ok(temperature)
+        temperature
     }
 
     /// Check if there is new accelerometer data
@@ -168,75 +241,116 @@ impl<I2C, E> Lsm6ds33<I2C>
 
     /// Read the accelerometer scale value from the configuration register
     pub async fn read_accelerometer_scale(&mut self) -> Result<AccelerometerScale, Error<E>> {
-        self.read_register_option(Register::Ctrl1XL).await
+        match self.accelerometer_scale {
+            Some(v) => Ok(v),
+            None => {
+                let scale = self.read_register_option(Register::Ctrl1XL).await?;
+                self.accelerometer_scale = Some(scale);
+                Ok(scale)
+            }
+        }
     }
 
     /// Read the gyroscope scale value from the configuration register
     pub async fn read_gyroscope_scale(&mut self) -> Result<GyroscopeFullScale, Error<E>> {
-        self.read_register_option(Register::Ctrl2G).await
-    }
-
-    async fn read_gyro_raw(&mut self) -> Result<(i16, i16, i16), Error<E>> {
-        self.read_sensor(Register::OutXLG).await
-    }
-
-    async fn read_accelerometer_raw(&mut self) -> Result<(i16, i16, i16), Error<E>> {
-        self.read_sensor(Register::OutXLXL).await
+        match self.gyroscope_scale {
+            Some(v) => Ok(v),
+            None => {
+                let scale = self.read_register_option(Register::Ctrl2G).await?;
+                self.gyroscope_scale = Some(scale);
+                Ok(scale)
+            }
+        }
     }
 
     async fn check(&mut self) -> Result<bool, Error<E>> {
-        self.read_register(Register::WhoAmI).await.map(|chip_id| chip_id == CHIP_ID)
+        self.read_register(Register::WhoAmI)
+            .await
+            .map(|chip_id| chip_id == CHIP_ID)
     }
 
     async fn set_auto_increment(&mut self, enabled: bool) -> Result<(), Error<E>> {
-        self.write_bit(Register::Ctrl3C, enabled as u8, Ctrl3C::AutoIncrement as u8).await
+        self.write_bit(Register::Ctrl3C, enabled as u8, Ctrl3C::AutoIncrement as u8)
+            .await
     }
 
     async fn read_status(&mut self) -> Result<u8, Error<E>> {
         self.read_register(Register::StatusReg).await
     }
 
-    async fn write_register_option<RO: RegisterOption>(&mut self, register: Register, ro: RO) -> Result<(), Error<E>> {
-        self.write_bits(register, ro.value(), RO::mask(), RO::bit_offset()).await
+    async fn write_register_option<RO: RegisterOption>(
+        &mut self,
+        register: Register,
+        ro: RO,
+    ) -> Result<(), Error<E>> {
+        self.write_bits(register, ro.value(), RO::mask(), RO::bit_offset())
+            .await
     }
 
-    async fn read_register_option<RO: RegisterOption + TryFrom<u8>>(&mut self, register: Register) -> Result<RO, Error<E>> {
+    async fn read_register_option<RO: RegisterOption + TryFrom<u8>>(
+        &mut self,
+        register: Register,
+    ) -> Result<RO, Error<E>> {
         let value = self.read_register(register).await?;
         RO::try_from(value).map_err(|_| Error::RegisterReadFailed)
     }
 
-    async fn write_bit(&mut self, register: Register, value: u8, shift: u8) -> Result<(), Error<E>> {
+    async fn write_bit(
+        &mut self,
+        register: Register,
+        value: u8,
+        shift: u8,
+    ) -> Result<(), Error<E>> {
         self.write_bits(register, value, 0x01, shift).await
     }
 
-    async fn write_bits(&mut self, register: Register, new_value: u8, mask: u8, shift: u8) -> Result<(), Error<E>> {
+    async fn write_bits(
+        &mut self,
+        register: Register,
+        new_value: u8,
+        mask: u8,
+        shift: u8,
+    ) -> Result<(), Error<E>> {
         let current_value = self.read_register(register).await?;
         let modified_value = (current_value & !(mask << shift)) | ((new_value & mask) << shift);
         self.write_register(register, modified_value).await
     }
 
-    async fn read_sensor(&mut self, start_reg: Register) -> Result<(i16, i16, i16), Error<E>> {
-        let mut res = [0u8; 6];
-        self.i2c.write_read(self.addr, &[start_reg.into()], &mut res).await.map(|_| {
-            (
-                (res[0] as i16) | ((res[1] as i16) << 8),
-                (res[2] as i16) | ((res[3] as i16) << 8),
-                (res[4] as i16) | ((res[5] as i16) << 8)
-            )
-        })
-        .map_err(Error::from)
+    fn u8_to_f32(res: &[u8; 6]) -> (f32, f32, f32) {
+        let (x, y, z) = (
+            (res[0] as i16) | ((res[1] as i16) << 8),
+            (res[2] as i16) | ((res[3] as i16) << 8),
+            (res[4] as i16) | ((res[5] as i16) << 8),
+        );
+        (x as f32, y as f32, z as f32)
     }
 
     // Read a byte from the given register
     async fn read_register(&mut self, register: Register) -> Result<u8, Error<E>> {
         let mut res = [0u8];
-        self.i2c.write_read(self.addr, &[register.into()], &mut res).await?;
+        self.i2c
+            .write_read(self.addr, &[register.into()], &mut res)
+            .await?;
         Ok(res[0])
+    }
+
+    async fn read_registers<const N: usize>(
+        &mut self,
+        start_reg: Register,
+    ) -> Result<[u8; N], Error<E>> {
+        let mut res = [0u8; N];
+        self.i2c
+            .write_read(self.addr, &[start_reg.into()], &mut res)
+            .await?;
+        Ok(res)
     }
 
     // Write the specified value to the given register
     async fn write_register(&mut self, register: Register, value: u8) -> Result<(), Error<E>> {
-        self.i2c.write(self.addr, &[register.into(), value]).await.map_err(Error::from)
+        self.i2c
+            .write(self.addr, &[register.into(), value])
+            .await
+            .map_err(Error::from)
     }
 
     /// Return the underlying I2C device

--- a/src/regs.rs
+++ b/src/regs.rs
@@ -9,7 +9,7 @@ use core::convert::TryFrom;
 
 #[derive(Debug)]
 pub enum RegisterError {
-    ConversionError
+    ConversionError,
 }
 
 // Device registers
@@ -112,13 +112,13 @@ pub trait RegisterOption {
 #[derive(Debug, Clone, Copy)]
 pub enum AccelerometerOutput {
     PowerDown = 0b0000,
-    Rate13    = 0b0001,
-    Rate26    = 0b0010,
-    Rate52    = 0b0011,
-    Rate104   = 0b0100,
-    Rate208   = 0b0101,
-    Rate416   = 0b0110,
-    Rate833   = 0b0111,
+    Rate13 = 0b0001,
+    Rate26 = 0b0010,
+    Rate52 = 0b0011,
+    Rate104 = 0b0100,
+    Rate208 = 0b0101,
+    Rate416 = 0b0110,
+    Rate833 = 0b0111,
     Rate1_66k = 0b1000,
     Rate3_33k = 0b1001,
     Rate6_66k = 0b1010,
@@ -188,7 +188,7 @@ pub enum AccelerometerBandwidth {
     Freq400 = 0b00,
     Freq200 = 0b01,
     Freq100 = 0b10,
-    Freq50  = 0b11,
+    Freq50 = 0b11,
 }
 
 impl RegisterOption for AccelerometerBandwidth {
@@ -210,13 +210,13 @@ impl RegisterOption for AccelerometerBandwidth {
 #[derive(Debug, Clone, Copy)]
 pub enum GyroscopeOutput {
     PowerDown = 0b0000,
-    Rate13    = 0b0001,
-    Rate26    = 0b0010,
-    Rate52    = 0b0011,
-    Rate104   = 0b0100,
-    Rate208   = 0b0101,
-    Rate416   = 0b0110,
-    Rate833   = 0b0111,
+    Rate13 = 0b0001,
+    Rate26 = 0b0010,
+    Rate52 = 0b0011,
+    Rate104 = 0b0100,
+    Rate208 = 0b0101,
+    Rate416 = 0b0110,
+    Rate833 = 0b0111,
     Rate1_66k = 0b1000,
     Rate3_33k = 0b1001,
     Rate6_66k = 0b1010,
@@ -258,9 +258,9 @@ impl RegisterOption for GyroscopeFullScale {
 impl GyroscopeFullScale {
     pub fn scale(&self) -> f32 {
         match *self {
-            Self::Dps125  => 4.375,
-            Self::Dps245  => 8.75,
-            Self::Dps500  => 17.50,
+            Self::Dps125 => 4.375,
+            Self::Dps245 => 8.75,
+            Self::Dps500 => 17.50,
             Self::Dps1000 => 35.0,
             Self::Dps2000 => 70.0,
         }


### PR DESCRIPTION
Reading the temperature, accelerometer, and gyroscope data with the existing API requires at least 6 I2C transactions. This PR refactors the code to minimize the number of transactions:

- Only one transaction to read both bytes of the temperature register
- Cache the accelerometer and gyroscope scale so their registers don't need to be read each time
- Adds a `read_all` function that reads all 14 bytes in a single transaction

With these changes, `read_all` can use a single I2C transaction to get all the sensor data.

I also ran `cargo fmt` which touched a few lines outside of what I changed in this PR.